### PR TITLE
fixes undefined variable complaint for collection items without mods

### DIFF
--- a/theme/islandora-mods-display-display-template.tpl.php
+++ b/theme/islandora-mods-display-display-template.tpl.php
@@ -11,4 +11,5 @@
  * @see theme_unicorns_are_awesome_display()
  */
 ?>
-<?php print $metadata;?>
+
+<?php print isset($metadata) ? $metadata :'';?>

--- a/theme/theme.inc
+++ b/theme/theme.inc
@@ -4,12 +4,12 @@
  * This file contains all theme and preprocess functions for islandora_mods_display.
  */
 
-
 /**
  * Implements hook_preprocess().
  */
 function islandora_mods_display_preprocess_islandora_mods_display_display(array &$variables) {
   $object = $variables['islandora_object'];
+  $mods = False;  
 
   if (islandora_datastream_access(ISLANDORA_VIEW_OBJECTS, $object['MODS'])) {
     try {


### PR DESCRIPTION
This fix suppressed an error message that occurred on collection level objects (that have no mods). Objects with mods are not affected by this suppression.
![mods_display_undef_var](https://cloud.githubusercontent.com/assets/3653599/15685878/6df9dcce-2733-11e6-94ad-9bb34b7d9ba0.png)
